### PR TITLE
alteração no nome do método fail para fugir do conflito de import

### DIFF
--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,0 +1,1 @@
+{"name":"sbt","version":"1.8.2","bspVersion":"2.1.0-M1","languages":["scala"],"argv":["/usr/lib/jvm/java-11-openjdk-amd64/bin/java","-Xms100m","-Xmx100m","-classpath","/home/dev/.local/share/JetBrains/IdeaIC2023.1/Scala/launcher/sbt-launch.jar","-Dsbt.script=/home/dev/.sdkman/candidates/sbt/current/bin/sbt","xsbt.boot.Boot","-bsp"]}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  pull_request:
+  push:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+      - name: Build and Test
+        run: sbt -v +test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+target
+*.class
+*.iml
+*.ipr
+*.iws
+.idea
+out

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.8.2

--- a/src/main/scala/br/unb/cic/parser/Parser.scala
+++ b/src/main/scala/br/unb/cic/parser/Parser.scala
@@ -31,7 +31,7 @@ def many[A](p : Parser[A]) : Parser[List[A]] = (input : String) => p(input) matc
 def pure[A](value: A): Parser[A] = (input: String) => List((value, input))
 
 /** Another primitive parser that always fails */
-def fail[A] : Parser[A] = (input: String) => Nil
+def failed[A] : Parser[A] = (input: String) => List()
 
 /** a combinator that receives two parsers and return the first one if it succeeds. Otherwise, returns the second one. */
 infix def choice[A] (p: Parser[A])(q: Parser[A]): Parser[A] = (input: String) => p(input) match {

--- a/src/test/scala/br/unb/cic/parser/ParserTest.scala
+++ b/src/test/scala/br/unb/cic/parser/ParserTest.scala
@@ -37,9 +37,9 @@ class ParserTest extends AnyFunSuite {
     assert(pure("MODULE")("abc") == List(("MODULE", "abc")))
   }
 
-  ignore("tests for the fail parser") {
-    assert(fail("abc") == Nil)
-    assert(fail("") == Nil)
+  test("tests for the fail parser") {
+    assert(failed("abc") == List())
+    assert(failed("") == List())
   }
 
   test("tests for the choice combinator") {


### PR DESCRIPTION
O Intellij estava considerando o método fail como pertencente ao pacote org.scalatest.Assertions. Uma alternativa seria utilizar o método fail do projeto com a referência direta ao pacote que queremos [exemplo: br.unb.parser.fail("abc")]. Mas para o import não fica desse modo, alterei o nome do método para "failed". 

Assim o import ficou apontando pro pacote correto e o teste passou. Adicionei um arquivo para disparar uma action do github em cada push ou pull request que fizermos (a action faz um build and test).